### PR TITLE
Add script for submitting any file containing a form submission

### DIFF
--- a/form_submission/form_submit_script.py
+++ b/form_submission/form_submit_script.py
@@ -1,0 +1,23 @@
+#!/bin/python3
+
+"""
+Script for submitting any form to CommCareHQ.
+"""
+
+from utils import submit_form, submit_form_with_app_id
+import sys
+
+def main():
+    arg_count = len(sys.argv) - 1
+    if arg_count == 4:
+        response = submit_form(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+    elif arg_count == 5:
+        response = submit_form_with_app_id(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+    else:
+        print("Form Submission script accepts either 4 or 5 arguments: filename, username, password, domain, and optionally app_id")
+        sys.exit(0)
+    print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/form_submission/utils.py
+++ b/form_submission/utils.py
@@ -4,7 +4,7 @@ from requests.auth import HTTPBasicAuth
 BASE_URL = "https://www.commcarehq.org"
 
 
-# same as
+# Same as
 #   curl --request POST -F xml_submission_file=@file.xml
 #   /a/your-domain/receiver -v -u
 #   username@your-domain.commcarehq.org:password
@@ -15,6 +15,26 @@ def submit_form(filename, username, password, domain):
     file_data = {'xml_submission_file':
                  (filename, open(filename, 'rb'), 'multipart/form-data')}
     url = "{0}/a/{1}/receiver/".format(BASE_URL, domain)
+    if "@" not in username:
+        # user is a web worker, so include proper domain
+        username = "{}@{}.commcarehq.org".format(username, domain)
+    r = requests.post(
+        url=url,
+        files=file_data,
+        auth=HTTPBasicAuth(username, password)
+    )
+    return r.status_code
+
+
+# Same as above, but submits to the url that includes app id, which is what usual form
+# submissions from mobile use. This is probably preferable when app id is available
+def submit_form_with_app_id(filename, username, password, domain, app_id):
+    """
+    Performs submission of xml file to CommCareHQ using basic auth
+    """
+    file_data = {'xml_submission_file':
+                 (filename, open(filename, 'rb'), 'multipart/form-data')}
+    url = "{0}/a/{1}/receiver/secure/{2}/".format(BASE_URL, domain, app_id)
     if "@" not in username:
         # user is a web worker, so include proper domain
         username = "{}@{}.commcarehq.org".format(username, domain)


### PR DESCRIPTION
Also added a method for doing form submission to the receiver url that includes app id, which is what mobile submits to. @phillipm It would probably be good to migrate everything to use this so that submissions from this script have total parity with mobile submissions. Right now, submissions that go to the url without app id show up on HQ like this: https://www.commcarehq.org/a/aliza-test/reports/case_data/4967f69c-6b0f-4917-bf00-fb10aac449cd/#!history?form_id=76c62d93-62e8-433f-8a9b-b37bdb58d063. I don't know all of the places that make use of this though so didn't want to mess with it for now.
